### PR TITLE
abstract pipe api via F[A, B]

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
 
       - uses: actions/checkout@v4
      

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
 
       - uses: actions/checkout@v4
      

--- a/pipe/README.md
+++ b/pipe/README.md
@@ -1,6 +1,6 @@
 # Type Safe Channels (`pipe`)
 
-Go's concurrency features simplify the creation of streaming data pipelines that effectively utilize I/O and multiple CPUs. [Go Concurrency Patterns: Pipelines and cancellation](https://go.dev/blog/pipelines) explains the topic in-depth. Despite the simplicity, the boilerplate code is required to build channels and establish "chrome" for its management. This module offers consistent operation over channels to form a processing pipelines in a clean and effective manner. 
+Go's concurrency features simplify the creation of streaming data pipelines that effectively utilize I/O and multiple CPUs. [Go Concurrency Patterns: Pipelines and cancellation](https://go.dev/blog/pipelines) explains the topic in-depth. Despite the simplicity, the boilerplate code is required to build channels and establish "chrome" for its management. This module offers consistent operation over channels to form a processing pipelines in a clean and type safe manner. 
 
 The module support sequential `pipe` and parallel `fork` type safe channels  for building pipelines. The module consider channels as "sequential data structure" trying to derive semantic from [stream interface](http://srfi.schemers.org/srfi-41/srfi-41.html)
 
@@ -19,27 +19,32 @@ func main() {
 
   // Generate sequence of integers
   ints := pipe.StdErr(pipe.Unfold(ctx, cap, 0,
-    func(x int) (int, error) { return x + 1, nil },
+    pipe.Pure(func(x int) int { return x + 1 }),
   ))
 
   // Limit sequence of integers
   ints10 := pipe.TakeWhile(ctx, ints,
-    func(x int) bool { return x <= 10 },
+    pipe.Pure(func(x int) bool { return x <= 10 }),
   )
 
   // Calculate squares
   sqrt := pipe.StdErr(pipe.Map(ctx, ints10,
-    func(x int) (int, error) { return x * x, nil },
+    pipe.Pure(func(x int) int { return x * x }),
   ))
 
   // Numbers to string
   vals := pipe.StdErr(pipe.Map(ctx, sqrt,
-    func(x int) (string, error) { return strconv.Itoa(x), nil },
+    pipe.Pure(strconv.Itoa),
   ))
 
   // Output strings
   <-pipe.ForEach(ctx, vals,
-    func(x string) { fmt.Printf("==> %s\n", x) },
+    pipe.Pure(
+      func(x string) string {
+        fmt.Printf("==> %s\n", x)
+        return x
+      },
+    ),
   )
 
   close()

--- a/pipe/examples/numbers/main.go
+++ b/pipe/examples/numbers/main.go
@@ -13,7 +13,7 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/fogfish/golem/pipe"
+	"github.com/fogfish/golem/pipe/v2"
 )
 
 const (
@@ -25,27 +25,32 @@ func main() {
 
 	// Generate sequence of integers
 	ints := pipe.StdErr(pipe.Unfold(ctx, cap, 0,
-		func(x int) (int, error) { return x + 1, nil },
+		pipe.Pure(func(x int) int { return x + 1 }),
 	))
 
 	// Limit sequence of integers
 	ints10 := pipe.TakeWhile(ctx, ints,
-		func(x int) bool { return x <= 10 },
+		pipe.Pure(func(x int) bool { return x <= 10 }),
 	)
 
 	// Calculate squares
 	sqrt := pipe.StdErr(pipe.Map(ctx, ints10,
-		func(x int) (int, error) { return x * x, nil },
+		pipe.Pure(func(x int) int { return x * x }),
 	))
 
 	// Numbers to string
 	vals := pipe.StdErr(pipe.Map(ctx, sqrt,
-		func(x int) (string, error) { return strconv.Itoa(x), nil },
+		pipe.Pure(strconv.Itoa),
 	))
 
 	// Output strings
 	<-pipe.ForEach(ctx, vals,
-		func(x string) { fmt.Printf("==> %s\n", x) },
+		pipe.Pure(
+			func(x string) string {
+				fmt.Printf("==> %s\n", x)
+				return x
+			},
+		),
 	)
 
 	close()

--- a/pipe/examples/throttling/main.go
+++ b/pipe/examples/throttling/main.go
@@ -14,7 +14,7 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/fogfish/golem/pipe"
+	"github.com/fogfish/golem/pipe/v2"
 )
 
 const (
@@ -27,7 +27,7 @@ func main() {
 
 	// Generate sequence of integers
 	fast := pipe.StdErr(pipe.Unfold(ctx, fastProducer, 0,
-		func(x int) (int, error) { return x + 1, nil },
+		pipe.Pure(func(x int) int { return x + 1 }),
 	))
 
 	// Throttle the "fast" pipe
@@ -35,14 +35,17 @@ func main() {
 
 	// Numbers to string
 	vals := pipe.StdErr(pipe.Map(ctx, slow,
-		func(x int) (string, error) { return strconv.Itoa(x), nil },
+		pipe.Pure(strconv.Itoa),
 	))
 
 	// Output strings
 	<-pipe.ForEach(ctx, vals,
-		func(x string) {
-			fmt.Printf("==> %s | %s\n", time.Now().Format(time.StampMilli), x)
-		},
+		pipe.Pure(
+			func(x string) string {
+				fmt.Printf("==> %s | %s\n", time.Now().Format(time.StampMilli), x)
+				return x
+			},
+		),
 	)
 
 	close()

--- a/pipe/fork/fork_test.go
+++ b/pipe/fork/fork_test.go
@@ -16,7 +16,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fogfish/golem/pipe/fork"
+	"github.com/fogfish/golem/pipe/v2/fork"
 	"github.com/fogfish/golem/pure/monoid"
 	"github.com/fogfish/it/v2"
 )
@@ -24,32 +24,28 @@ import (
 const par = 4
 
 func TestEmit(t *testing.T) {
-	seq := 0
-	emit := func() (int, error) {
-		seq++
-		return seq, nil
-	}
+	emit := fork.Pure(func(x int) int { return x })
 
 	ctx, close := context.WithCancel(context.Background())
 	eg := fork.StdErr(fork.Emit(ctx, 0, 10*time.Microsecond, emit))
 
 	it.Then(t).Should(
+		it.Equal(<-eg, 0),
 		it.Equal(<-eg, 1),
 		it.Equal(<-eg, 2),
 		it.Equal(<-eg, 3),
 		it.Equal(<-eg, 4),
 		it.Equal(<-eg, 5),
-		it.Equal(<-eg, 6),
 	)
 	close()
 }
 
 func TestFilter(t *testing.T) {
+	fun := fork.Pure(func(x int) bool { return x%2 == 1 })
+
 	ctx, close := context.WithCancel(context.Background())
 	seq := fork.Seq(1, 2, 3, 4, 5)
-	out := fork.Filter(ctx, par, seq,
-		func(x int) bool { return x%2 == 1 },
-	)
+	out := fork.Filter(ctx, par, seq, fun)
 
 	it.Then(t).Should(
 		it.Seq(fork.ToSeq(out)).Contain().AllOf(1, 3, 5),
@@ -59,17 +55,18 @@ func TestFilter(t *testing.T) {
 }
 
 func TestForEach(t *testing.T) {
-	ctx, close := context.WithCancel(context.Background())
-
-	seq := fork.Seq(1, 2, 3, 4, 5)
-
 	var m sync.Mutex
 	n := 0
-	<-fork.ForEach(ctx, par, seq, func(a int) {
+	fun := fork.Pure(func(a int) int {
 		m.Lock()
 		defer m.Unlock()
 		n = n + a
+		return n
 	})
+
+	ctx, close := context.WithCancel(context.Background())
+	seq := fork.Seq(1, 2, 3, 4, 5)
+	<-fork.ForEach(ctx, par, seq, fun)
 
 	it.Then(t).Should(
 		it.Equal(n, 15),
@@ -80,14 +77,16 @@ func TestForEach(t *testing.T) {
 
 func TestFMap(t *testing.T) {
 	t.Run("FMap", func(t *testing.T) {
-		ctx, close := context.WithCancel(context.Background())
-		seq := fork.Seq(1, 2, 3, 4, 5)
-		out := fork.StdErr(fork.FMap(ctx, par, seq,
+		fun := fork.LiftF(
 			func(ctx context.Context, x int, ch chan<- string) error {
 				ch <- strconv.Itoa(x)
 				return nil
-			}),
+			},
 		)
+
+		ctx, close := context.WithCancel(context.Background())
+		seq := fork.Seq(1, 2, 3, 4, 5)
+		out := fork.StdErr(fork.FMap(ctx, par, seq, fun))
 
 		it.Then(t).Should(
 			it.Seq(fork.ToSeq(out)).Contain().AllOf("1", "2", "3", "4", "5"),
@@ -97,13 +96,15 @@ func TestFMap(t *testing.T) {
 	})
 
 	t.Run("Err", func(t *testing.T) {
-		ctx, close := context.WithCancel(context.Background())
-		seq := fork.Seq(1, 2, 3, 4, 5)
-		_, exx := fork.FMap(ctx, par, seq,
+		fun := fork.LiftF(
 			func(ctx context.Context, x int, ch chan<- string) error {
 				return fmt.Errorf("fail")
 			},
 		)
+
+		ctx, close := context.WithCancel(context.Background())
+		seq := fork.Seq(1, 2, 3, 4, 5)
+		_, exx := fork.FMap(ctx, par, seq, fun)
 
 		it.Then(t).ShouldNot(
 			it.Nil(<-exx),
@@ -113,35 +114,30 @@ func TestFMap(t *testing.T) {
 	})
 
 	t.Run("Cancel", func(t *testing.T) {
-		acc := 0
-		emit := func() (int, error) {
-			acc++
-			return acc, nil
-		}
-
-		ctx, close := context.WithCancel(context.Background())
-		seq := fork.StdErr(fork.Emit(ctx, 1000, 10*time.Microsecond, emit))
-		out := fork.StdErr(fork.FMap(ctx, par, seq,
+		emit := fork.Pure(func(x int) int { return x })
+		fun := fork.LiftF(
 			func(ctx context.Context, x int, ch chan<- int) error {
 				ch <- x
 				return nil
-			}),
+			},
 		)
 
+		ctx, close := context.WithCancel(context.Background())
+		seq := fork.StdErr(fork.Emit(ctx, 1000, 10*time.Microsecond, emit))
+		out := fork.StdErr(fork.FMap(ctx, par, seq, fun))
 		vals := fork.ToSeq(fork.Take(ctx, out, 10))
 		close()
 
 		it.Then(t).Should(
-			it.Seq(vals).Contain().AllOf(1, 2, 3, 4, 5, 6, 7, 8, 9, 10),
+			it.Seq(vals).Contain().AllOf(0, 1, 2, 3, 4, 5, 6, 7, 8, 9),
 		)
 	})
 }
 
 func TestFold(t *testing.T) {
+	acc := monoid.FromOp(0, func(a, b int) int { return a + b })
 	seq := fork.Seq(1, 2, 3, 4, 5)
-	n := <-fork.Fold(context.Background(), par, seq,
-		monoid.FromOp(0, func(a, b int) int { return a + b }),
-	)
+	n := <-fork.Fold(context.Background(), par, seq, acc)
 
 	it.Then(t).Should(
 		it.Equal(n, 15),
@@ -150,11 +146,11 @@ func TestFold(t *testing.T) {
 
 func TestMap(t *testing.T) {
 	t.Run("Map", func(t *testing.T) {
+		fun := fork.Pure(strconv.Itoa)
+
 		ctx, close := context.WithCancel(context.Background())
 		seq := fork.Seq(1, 2, 3, 4, 5)
-		out := fork.StdErr(fork.Map(ctx, par, seq,
-			func(x int) (string, error) { return strconv.Itoa(x), nil },
-		))
+		out := fork.StdErr(fork.Map(ctx, par, seq, fun))
 
 		it.Then(t).Should(
 			it.Seq(fork.ToSeq(out)).Contain().AllOf("1", "2", "3", "4", "5"),
@@ -163,11 +159,11 @@ func TestMap(t *testing.T) {
 	})
 
 	t.Run("Err", func(t *testing.T) {
+		fun := fork.Lift(func(x int) (string, error) { return "", fmt.Errorf("fail") })
+
 		ctx, close := context.WithCancel(context.Background())
 		seq := fork.Seq(1, 2, 3, 4, 5)
-		_, exx := fork.Map(ctx, par, seq,
-			func(x int) (string, error) { return "", fmt.Errorf("fail") },
-		)
+		_, exx := fork.Map(ctx, par, seq, fun)
 
 		it.Then(t).ShouldNot(
 			it.Nil(<-exx),
@@ -178,11 +174,11 @@ func TestMap(t *testing.T) {
 }
 
 func TestPartition(t *testing.T) {
+	fun := fork.Pure(func(x int) bool { return x%2 == 1 })
+
 	ctx, close := context.WithCancel(context.Background())
 	seq := fork.Seq(1, 2, 3, 4, 5)
-	lo, ro := fork.Partition(ctx, par, seq,
-		func(x int) bool { return x%2 == 1 },
-	)
+	lo, ro := fork.Partition(ctx, par, seq, fun)
 
 	it.Then(t).Should(
 		it.Seq(fork.ToSeq(lo)).Equal(1, 3, 5),
@@ -193,8 +189,10 @@ func TestPartition(t *testing.T) {
 }
 
 func TestUnfold(t *testing.T) {
+	fun := fork.Pure(func(x int) int { return x + 1 })
+
 	ctx, close := context.WithCancel(context.Background())
-	seq := fork.StdErr(fork.Unfold(ctx, 1, 0, func(x int) (int, error) { return x + 1, nil }))
+	seq := fork.StdErr(fork.Unfold(ctx, 1, 0, fun))
 
 	it.Then(t).Should(
 		it.Equal(<-seq, 0),
@@ -236,9 +234,11 @@ func TestTake(t *testing.T) {
 }
 
 func TestTakeWhile(t *testing.T) {
+	fun := fork.Pure(func(x int) bool { return x < 4 })
+
 	ctx, close := context.WithCancel(context.Background())
 	seq := fork.Seq(1, 2, 3, 4, 5, 6)
-	out := fork.TakeWhile(ctx, seq, func(x int) bool { return x < 4 })
+	out := fork.TakeWhile(ctx, seq, fun)
 
 	it.Then(t).Should(
 		it.Seq(fork.ToSeq(out)).Equal(1, 2, 3),
@@ -252,9 +252,9 @@ func TestThrottling(t *testing.T) {
 	seq := fork.Seq(1, 2, 3, 4, 5, 6, 7, 8, 9, 0)
 	slowSeq := fork.Throttling(ctx, seq, 1, 100*time.Millisecond)
 	out := fork.StdErr(fork.Map(ctx, par, slowSeq,
-		func(_ int) (time.Time, error) {
+		fork.Lift(func(_ int) (time.Time, error) {
 			return time.Now(), nil
-		},
+		}),
 	))
 	wt := fork.ToSeq(out)
 	for i := 1; i < len(wt); i++ {

--- a/pipe/fork/function.go
+++ b/pipe/fork/function.go
@@ -45,19 +45,23 @@ func Lift[A, B any](f EitherE[A, B]) F[A, B] {
 
 type pure[A, B any] EitherE[A, B]
 
+//lint:ignore U1000 false positive
 func (f pure[A, B]) apply(a A) (B, error) {
 	return EitherE[A, B](f)(a)
 }
 
+//lint:ignore U1000 false positive
 func (f pure[A, B]) errch(_ int) chan error {
 	return make(chan error, 1)
 }
 
+//lint:ignore U1000 false positive
 func (f pure[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool {
 	exx <- err
 	return false
 }
 
+//lint:ignore U1000 false positive
 func (f pure[A, B]) pipef() pipe.F[A, B] {
 	return pipe.Lift(f)
 }
@@ -70,14 +74,17 @@ func Try[A, B any](f EitherE[A, B]) F[A, B] {
 
 type try[A, B any] EitherE[A, B]
 
+//lint:ignore U1000 false positive
 func (f try[A, B]) apply(a A) (B, error) {
 	return EitherE[A, B](f)(a)
 }
 
+//lint:ignore U1000 false positive
 func (f try[A, B]) errch(cap int) chan error {
 	return make(chan error, cap)
 }
 
+//lint:ignore U1000 false positive
 func (f try[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool {
 	select {
 	case exx <- err:
@@ -87,6 +94,7 @@ func (f try[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool 
 	return true
 }
 
+//lint:ignore U1000 false positive
 func (f try[A, B]) pipef() pipe.F[A, B] {
 	return pipe.Lift(f)
 }
@@ -108,14 +116,17 @@ func LiftF[A, B any](f Arrow[A, B]) FF[A, B] {
 
 type puref[A, B any] Arrow[A, B]
 
+//lint:ignore U1000 false positive
 func (f puref[A, B]) apply(ctx context.Context, a A, b chan<- B) error {
 	return Arrow[A, B](f)(ctx, a, b)
 }
 
+//lint:ignore U1000 false positive
 func (f puref[A, B]) errch(_ int) chan error {
 	return make(chan error, 1)
 }
 
+//lint:ignore U1000 false positive
 func (f puref[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool {
 	exx <- err
 	return false
@@ -129,14 +140,17 @@ func TryF[A, B any](f Arrow[A, B]) FF[A, B] {
 
 type tryf[A, B any] Arrow[A, B]
 
+//lint:ignore U1000 false positive
 func (f tryf[A, B]) apply(ctx context.Context, a A, b chan<- B) error {
 	return Arrow[A, B](f)(ctx, a, b)
 }
 
+//lint:ignore U1000 false positive
 func (f tryf[A, B]) errch(cap int) chan error {
 	return make(chan error, cap)
 }
 
+//lint:ignore U1000 false positive
 func (f tryf[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool {
 	select {
 	case exx <- err:

--- a/pipe/fork/function.go
+++ b/pipe/fork/function.go
@@ -96,7 +96,7 @@ func (f try[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool 
 
 //lint:ignore U1000 false positive
 func (f try[A, B]) pipef() pipe.F[A, B] {
-	return pipe.Lift(f)
+	return pipe.Try(f)
 }
 
 //------------------------------------------------------------------------------

--- a/pipe/fork/function.go
+++ b/pipe/fork/function.go
@@ -1,0 +1,147 @@
+//
+// Copyright (C) 2022 - 2025 Dmitry Kolesnikov
+//
+// This file may be modified and distributed under the terms
+// of the MIT license.  See the LICENSE file for details.
+// https://github.com/fogfish/golem
+//
+
+package fork
+
+import (
+	"context"
+
+	"github.com/fogfish/golem/pipe/v2"
+)
+
+// Pure effect over category A ⟼ B
+type E[A, B any] = func(A) B
+
+// Either effect over category A ⟼ (B, error)
+type EitherE[A, B any] = func(A) (B, error)
+
+// Arrow over functor 𝓕: A ⟼ B
+type Arrow[A, B any] = func(context.Context, A, chan<- B) error
+
+// Go channel morphism 𝑓: A ⟼ B
+type F[A, B any] interface {
+	apply(A) (B, error)
+	errch(cap int) chan error
+	catch(context.Context, error, chan<- error) bool
+	pipef() pipe.F[A, B]
+}
+
+// Lift pure effect into morphism 𝑓: A ⟼ B
+func Pure[A, B any](f E[A, B]) F[A, B] {
+	ff := func(a A) (B, error) { return f(a), nil }
+	return pure[A, B](ff)
+}
+
+// Lift either effect into morphism 𝑓: A ⟼ B
+// The failure of morphism causes the failure of channel, aborts the computation.
+func Lift[A, B any](f EitherE[A, B]) F[A, B] {
+	return pure[A, B](f)
+}
+
+type pure[A, B any] EitherE[A, B]
+
+func (f pure[A, B]) apply(a A) (B, error) {
+	return EitherE[A, B](f)(a)
+}
+
+func (f pure[A, B]) errch(_ int) chan error {
+	return make(chan error, 1)
+}
+
+func (f pure[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool {
+	exx <- err
+	return false
+}
+
+func (f pure[A, B]) pipef() pipe.F[A, B] {
+	return pipe.Lift(f)
+}
+
+// Lift either effect into morphism 𝑓: A ⟼ B
+// The failure of morphism causes the failure of step, continues the computation.
+func Try[A, B any](f EitherE[A, B]) F[A, B] {
+	return try[A, B](f)
+}
+
+type try[A, B any] EitherE[A, B]
+
+func (f try[A, B]) apply(a A) (B, error) {
+	return EitherE[A, B](f)(a)
+}
+
+func (f try[A, B]) errch(cap int) chan error {
+	return make(chan error, cap)
+}
+
+func (f try[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool {
+	select {
+	case exx <- err:
+	case <-ctx.Done():
+		return false
+	}
+	return true
+}
+
+func (f try[A, B]) pipef() pipe.F[A, B] {
+	return pipe.Lift(f)
+}
+
+//------------------------------------------------------------------------------
+
+// Go channel functor 𝓕: A ⟼ B
+type FF[A, B any] interface {
+	apply(context.Context, A, chan<- B) error
+	errch(cap int) chan error
+	catch(context.Context, error, chan<- error) bool
+}
+
+// Lift arrow into functor morphism 𝓕: A ⟼ B
+// The failure of morphism causes the failure of channel, aborts the computation.
+func LiftF[A, B any](f Arrow[A, B]) FF[A, B] {
+	return puref[A, B](f)
+}
+
+type puref[A, B any] Arrow[A, B]
+
+func (f puref[A, B]) apply(ctx context.Context, a A, b chan<- B) error {
+	return Arrow[A, B](f)(ctx, a, b)
+}
+
+func (f puref[A, B]) errch(_ int) chan error {
+	return make(chan error, 1)
+}
+
+func (f puref[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool {
+	exx <- err
+	return false
+}
+
+// Lift arrow into functor morphism 𝓕: A ⟼ B
+// The failure of morphism causes the failure of step, continues the computation.
+func TryF[A, B any](f Arrow[A, B]) FF[A, B] {
+	return tryf[A, B](f)
+}
+
+type tryf[A, B any] Arrow[A, B]
+
+func (f tryf[A, B]) apply(ctx context.Context, a A, b chan<- B) error {
+	return Arrow[A, B](f)(ctx, a, b)
+}
+
+func (f tryf[A, B]) errch(cap int) chan error {
+	return make(chan error, cap)
+}
+
+func (f tryf[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool {
+	select {
+	case exx <- err:
+	case <-ctx.Done():
+		return false
+	}
+	return true
+}

--- a/pipe/function.go
+++ b/pipe/function.go
@@ -1,0 +1,134 @@
+//
+// Copyright (C) 2022 - 2025 Dmitry Kolesnikov
+//
+// This file may be modified and distributed under the terms
+// of the MIT license.  See the LICENSE file for details.
+// https://github.com/fogfish/golem
+//
+
+package pipe
+
+import "context"
+
+// Pure effect over category A ⟼ B
+type E[A, B any] = func(A) B
+
+// Either effect over category A ⟼ (B, error)
+type EitherE[A, B any] = func(A) (B, error)
+
+// Arrow over functor 𝓕: A ⟼ B
+type Arrow[A, B any] = func(context.Context, A, chan<- B) error
+
+// Go channel morphism 𝑓: A ⟼ B
+type F[A, B any] interface {
+	apply(A) (B, error)
+	errch(cap int) chan error
+	catch(context.Context, error, chan<- error) bool
+}
+
+// Lift pure effect into morphism 𝑓: A ⟼ B
+func Pure[A, B any](f E[A, B]) F[A, B] {
+	ff := func(a A) (B, error) { return f(a), nil }
+	return pure[A, B](ff)
+}
+
+// Lift either effect into morphism 𝑓: A ⟼ B
+// The failure of morphism causes the failure of channel, aborts the computation.
+func Lift[A, B any](f EitherE[A, B]) F[A, B] {
+	return pure[A, B](f)
+}
+
+type pure[A, B any] EitherE[A, B]
+
+func (f pure[A, B]) apply(a A) (B, error) {
+	return EitherE[A, B](f)(a)
+}
+
+func (f pure[A, B]) errch(_ int) chan error {
+	return make(chan error, 1)
+}
+
+func (f pure[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool {
+	exx <- err
+	return false
+}
+
+// Lift either effect into morphism 𝑓: A ⟼ B
+// The failure of morphism causes the failure of step, continues the computation.
+func Try[A, B any](f EitherE[A, B]) F[A, B] {
+	return try[A, B](f)
+}
+
+type try[A, B any] EitherE[A, B]
+
+func (f try[A, B]) apply(a A) (B, error) {
+	return EitherE[A, B](f)(a)
+}
+
+func (f try[A, B]) errch(cap int) chan error {
+	return make(chan error, cap)
+}
+
+func (f try[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool {
+	select {
+	case exx <- err:
+	case <-ctx.Done():
+		return false
+	}
+	return true
+}
+
+//------------------------------------------------------------------------------
+
+// Go channel functor 𝓕: A ⟼ B
+type FF[A, B any] interface {
+	apply(context.Context, A, chan<- B) error
+	errch(cap int) chan error
+	catch(context.Context, error, chan<- error) bool
+}
+
+// Lift arrow into functor morphism 𝓕: A ⟼ B
+// The failure of morphism causes the failure of channel, aborts the computation.
+func LiftF[A, B any](f Arrow[A, B]) FF[A, B] {
+	return puref[A, B](f)
+}
+
+type puref[A, B any] Arrow[A, B]
+
+func (f puref[A, B]) apply(ctx context.Context, a A, b chan<- B) error {
+	return Arrow[A, B](f)(ctx, a, b)
+}
+
+func (f puref[A, B]) errch(_ int) chan error {
+	return make(chan error, 1)
+}
+
+func (f puref[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool {
+	exx <- err
+	return false
+}
+
+// Lift arrow into functor morphism 𝓕: A ⟼ B
+// The failure of morphism causes the failure of step, continues the computation.
+func TryF[A, B any](f Arrow[A, B]) FF[A, B] {
+	return tryf[A, B](f)
+}
+
+type tryf[A, B any] Arrow[A, B]
+
+func (f tryf[A, B]) apply(ctx context.Context, a A, b chan<- B) error {
+	return Arrow[A, B](f)(ctx, a, b)
+}
+
+func (f tryf[A, B]) errch(cap int) chan error {
+	return make(chan error, cap)
+}
+
+func (f tryf[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool {
+	select {
+	case exx <- err:
+	case <-ctx.Done():
+		return false
+	}
+	return true
+}

--- a/pipe/function.go
+++ b/pipe/function.go
@@ -40,14 +40,17 @@ func Lift[A, B any](f EitherE[A, B]) F[A, B] {
 
 type pure[A, B any] EitherE[A, B]
 
+//lint:ignore U1000 false positive
 func (f pure[A, B]) apply(a A) (B, error) {
 	return EitherE[A, B](f)(a)
 }
 
+//lint:ignore U1000 false positive
 func (f pure[A, B]) errch(_ int) chan error {
 	return make(chan error, 1)
 }
 
+//lint:ignore U1000 false positive
 func (f pure[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool {
 	exx <- err
 	return false
@@ -61,14 +64,17 @@ func Try[A, B any](f EitherE[A, B]) F[A, B] {
 
 type try[A, B any] EitherE[A, B]
 
+//lint:ignore U1000 false positive
 func (f try[A, B]) apply(a A) (B, error) {
 	return EitherE[A, B](f)(a)
 }
 
+//lint:ignore U1000 false positive
 func (f try[A, B]) errch(cap int) chan error {
 	return make(chan error, cap)
 }
 
+//lint:ignore U1000 false positive
 func (f try[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool {
 	select {
 	case exx <- err:
@@ -95,14 +101,17 @@ func LiftF[A, B any](f Arrow[A, B]) FF[A, B] {
 
 type puref[A, B any] Arrow[A, B]
 
+//lint:ignore U1000 false positive
 func (f puref[A, B]) apply(ctx context.Context, a A, b chan<- B) error {
 	return Arrow[A, B](f)(ctx, a, b)
 }
 
+//lint:ignore U1000 false positive
 func (f puref[A, B]) errch(_ int) chan error {
 	return make(chan error, 1)
 }
 
+//lint:ignore U1000 false positive
 func (f puref[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool {
 	exx <- err
 	return false
@@ -116,14 +125,17 @@ func TryF[A, B any](f Arrow[A, B]) FF[A, B] {
 
 type tryf[A, B any] Arrow[A, B]
 
+//lint:ignore U1000 false positive
 func (f tryf[A, B]) apply(ctx context.Context, a A, b chan<- B) error {
 	return Arrow[A, B](f)(ctx, a, b)
 }
 
+//lint:ignore U1000 false positive
 func (f tryf[A, B]) errch(cap int) chan error {
 	return make(chan error, cap)
 }
 
+//lint:ignore U1000 false positive
 func (f tryf[A, B]) catch(ctx context.Context, err error, exx chan<- error) bool {
 	select {
 	case exx <- err:

--- a/pipe/go.mod
+++ b/pipe/go.mod
@@ -1,8 +1,6 @@
-module github.com/fogfish/golem/pipe
+module github.com/fogfish/golem/pipe/v2
 
-go 1.22
-
-toolchain go1.22.2
+go 1.24
 
 require (
 	github.com/fogfish/golem/pure v0.10.1

--- a/pipe/unbound_test.go
+++ b/pipe/unbound_test.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/fogfish/golem/pipe"
+	"github.com/fogfish/golem/pipe/v2"
 	"github.com/fogfish/it/v2"
 )
 

--- a/pipe/version.go
+++ b/pipe/version.go
@@ -8,4 +8,4 @@
 
 package pipe
 
-const Version = "pipe/v1.2.0"
+const Version = "pipe/v2.0.0"


### PR DESCRIPTION
The library defines a Go channel morphism F[A, B] with support of different error handling strategies Pure, Lift, Try and also FMap equivalents